### PR TITLE
Postコントローラークラスの作成

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+//use宣言は外部にあるクラスをGuitarController内にインポートできる。
+//この場合、App\Models内のGuitarクラスをインポートしている。
+use App\Models\Post;
+
+class PostController extends Controller
+{
+    public function index(Post $post) //インポートしたGuitarをインスタンス化して$guitarとして使用。
+    {
+        return $post->get(); //$guitarの中身を戻り値にする。
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use HasFactory;
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PostController;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,3 +17,5 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/posts', [PostController::class, 'index']);


### PR DESCRIPTION
Postコントローラークラスの作成
Postテーブル操作用モデルクラスの作成
Postコントローラークラスの実装
Postコントローラーへのルーティング設定

＊ModelクラスやControllerクラスの名前を当初GuitarやGuitarControllerと命名していたが、テーブル名をpostsとしてしまったため、統一した。